### PR TITLE
chore: store current network in user objects in the database

### DIFF
--- a/.project/guides/network_setup.md
+++ b/.project/guides/network_setup.md
@@ -16,7 +16,7 @@ A walkthrough for setting up a network in the Home Orchestrator system. New user
 	{
 		_id: {Auto-ID}, // String (matching the generated ID above)
 		name: {network name}, // String (this can be whatever you like)
-		owner: {your email}, // String (this must be the account you use to log in)
+		ownerId: {your uid}, // String (found at: https://console.firebase.google.com/u/0/project/holistic-home-5134d/authentication/users)
 		variables: {empty} // Map (leave this empty for now)
 	}
 	```

--- a/orchestration-api/.gcloudignore
+++ b/orchestration-api/.gcloudignore
@@ -1,0 +1,17 @@
+# This file specifies files that are *not* uploaded to Google Cloud Platform
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+# If you would like to upload your .git directory, .gitignore file or files
+# from your .gitignore file, remove the corresponding line
+# below:
+.git
+.gitignore
+
+# Node.js dependencies:
+node_modules/

--- a/orchestration-api/app.js
+++ b/orchestration-api/app.js
@@ -17,6 +17,7 @@ app.use(cors());
 app.use(bodyParser.json());
 
 app.use('/lights', routes.LightsController);
+app.use('/me'. routes.MeController);
 app.use('/networks', routes.NetworksController)
 app.use('/themes', routes.ThemesController);
 app.use('/users', routes.UsersController);

--- a/orchestration-api/app.js
+++ b/orchestration-api/app.js
@@ -17,7 +17,7 @@ app.use(cors());
 app.use(bodyParser.json());
 
 app.use('/lights', routes.LightsController);
-app.use('/me'. routes.MeController);
+app.use('/me', routes.MeController);
 app.use('/networks', routes.NetworksController)
 app.use('/themes', routes.ThemesController);
 app.use('/users', routes.UsersController);

--- a/orchestration-api/clients/FirebaseClient.js
+++ b/orchestration-api/clients/FirebaseClient.js
@@ -1,0 +1,47 @@
+const admin = require('firebase-admin');
+
+module.exports = {
+
+	async getCollection(collectionPath) {
+		const collectionSnapshot = await admin.firestore().collection(collectionPath).get();
+		const items = collectionSnapshot.docs.map(doc => doc.data());
+		return items;
+	},
+
+	async getDocument(documentPath) {
+		const documentSnapshot = await admin.firestore().doc(documentPath).get();
+		const item = documentSnapshot.data();
+		return item;
+	},
+
+	async createDocument(collectionPath, data) {
+		const documentRef = admin.firestore().collection(collectionPath).doc();
+		data._id = documentRef.id;
+		await documentRef.set(data);
+		return data;
+	},
+
+	async setDocument(documentPath, data) {
+		const pathParts = documentPath.split('/');
+		data._id = pathParts[pathParts.length - 1];
+		const documentRef = admin.firestore().doc(documentPath);
+		await documentRef.update(data);
+		return data;
+	},
+
+	async updateDocument(documentPath, data) {
+		const { _id } = data;
+		delete data._id;
+		const documentRef = admin.firestore().doc(documentPath);
+		await documentRef.update(data);
+		data._id = _id;
+		return data;
+	},
+
+	async deleteDocument(documentPath) {
+		const documentRef = admin.firestore().doc(documentPath);
+		await documentRef.delete();
+		return documentPath;
+	}
+
+}

--- a/orchestration-api/clients/FirebaseClient.js
+++ b/orchestration-api/clients/FirebaseClient.js
@@ -25,7 +25,7 @@ module.exports = {
 		const pathParts = documentPath.split('/');
 		data._id = pathParts[pathParts.length - 1];
 		const documentRef = admin.firestore().doc(documentPath);
-		await documentRef.update(data);
+		await documentRef.set(data);
 		return data;
 	},
 

--- a/orchestration-api/modules/lights/LightsController.js
+++ b/orchestration-api/modules/lights/LightsController.js
@@ -7,7 +7,8 @@ const lightService = new LightService();
 
 router.post('/update', async (req, res, next) => {
 	try {
-		const { lights, networkId } = req.body;
+		const { lights, userId } = req.body;
+		const { networkId } = await getDocument(`users/${userId}`);
 
 		const lightPromises = lights.map(async light => {
 			const result = await updateDocument(`networks/${networkId}/lights/${light._id}`, light);
@@ -25,13 +26,14 @@ router.post('/update', async (req, res, next) => {
 });
 
 router.get('/', async (req, res, next) => {
-    try {
-		const { networkId } = req.query;
+	try {
+		const { userId } = req.query;
+		const { networkId } = await getDocument(`users/${userId}`);
 		const lights = await getCollection(`networks/${networkId}/lights`);
 		return res.send(lights);
-    } catch (err) {
-        next(err);
-    }
+	} catch (err) {
+		next(err);
+	}
 });
 
 module.exports = router;

--- a/orchestration-api/modules/lights/LightsController.js
+++ b/orchestration-api/modules/lights/LightsController.js
@@ -1,5 +1,5 @@
 const { Router } = require('express');
-const admin = require('firebase-admin');
+const { getCollection, getDocument, updateDocument } = require('../../clients/FirebaseClient');
 const LightService = require('./LightService');
 
 const router = Router();
@@ -8,27 +8,17 @@ const lightService = new LightService();
 router.post('/update', async (req, res, next) => {
 	try {
 		const { lights, networkId } = req.body;
-		console.log('> lights/update~ called with: ' + JSON.stringify({ lights, networkId }, null, 4));
 
-		// Update the Database
-		const batchWrite = admin.firestore().batch();
-		lights.forEach(light => {
-			lightRef = admin.firestore().collection('networks').doc(networkId).collection('lights').doc(light._id);
-			batchWrite.update(lightRef, light);
+		const lightPromises = lights.map(async light => {
+			const result = await updateDocument(`networks/${networkId}/lights/${light._id}`, light);
+			return result;
 		});
-		await batchWrite.commit();
+		await Promise.all(lightPromises);
 
-		// Get the network
-		const networkDoc = admin.firestore().collection('networks').doc(networkId);
-		const networkSnap = await networkDoc.get();
-		const network = networkSnap.data();
-
-		// Update the lights
-		console.log('> updateLights~ updating the lights\' state');
+		const network = await getDocument(`networks/${networkId}`);
 		await lightService.updateLights(lights, network);
 
 		return res.send('done');
-
 	} catch (err) {
 		next(err);
 	}
@@ -37,8 +27,7 @@ router.post('/update', async (req, res, next) => {
 router.get('/', async (req, res, next) => {
     try {
 		const { networkId } = req.query;
-		const lightsSnapshots = await admin.firestore().collection('networks').doc(networkId).collection('lights').get();
-		const lights = lightsSnapshots.docs.map(doc => doc.data());
+		const lights = await getCollection(`networks/${networkId}/lights`);
 		return res.send(lights);
     } catch (err) {
         next(err);

--- a/orchestration-api/modules/me/MeController.js
+++ b/orchestration-api/modules/me/MeController.js
@@ -34,4 +34,15 @@ router.get('/network', async (req, res, next) => {
 	}
 });
 
+router.patch('/network', async (req, res, next) => {
+	try {
+		const { userId, network } = req.body;
+		const { networkId } = await getDocument(`users/${userId}`);
+		const result = await updateDocument(`networks/${networkId}`, network);
+		return res.send(result);
+	} catch(err) {
+		next(err);
+	}
+});
+
 module.exports = router;

--- a/orchestration-api/modules/me/MeController.js
+++ b/orchestration-api/modules/me/MeController.js
@@ -1,0 +1,26 @@
+const { Router } = require('express');
+const { getDocument, updateDocument } = require('../../clients/FirebaseClient');
+
+const router = Router();
+
+router.get('/', async (req, res, next) => {
+	try {
+		const { userId } = req.query;
+		const user = await getDocument(`users/${userId}`);
+		return res.send(user);
+	} catch (err) {
+		next(err);
+	}
+});
+
+router.patch('/networkId', async (req, res, next) => {
+	try {
+		const { userId, netwokId } = req.body;
+		const result = await updateDocument(`users/${userId}`, { networkId });
+		return res.send(result);
+	} catch (err) {
+		next(err);
+	}
+});
+
+module.exports = router;

--- a/orchestration-api/modules/me/MeController.js
+++ b/orchestration-api/modules/me/MeController.js
@@ -15,10 +15,21 @@ router.get('/', async (req, res, next) => {
 
 router.patch('/networkId', async (req, res, next) => {
 	try {
-		const { userId, netwokId } = req.body;
+		const { userId, networkId } = req.body;
 		const result = await updateDocument(`users/${userId}`, { networkId });
 		return res.send(result);
 	} catch (err) {
+		next(err);
+	}
+});
+
+router.get('/network', async (req, res, next) => {
+	try {
+		const { userId } = req.query;
+		const { networkId } = await getDocument(`users/${userId}`);
+		const network = await getDocument(`networks/${networkId}`);
+		return res.send(network);
+	} catch(err) {
 		next(err);
 	}
 });

--- a/orchestration-api/modules/networks/NetworksController.js
+++ b/orchestration-api/modules/networks/NetworksController.js
@@ -1,12 +1,11 @@
 const { Router } = require('express');
-const { getCollection, updateDocument } = require('../../clients/FirebaseClient');
+const { getCollection } = require('../../clients/FirebaseClient');
 
 const router = Router();
 
 router.get('/', async (req, res, next) => {
 	try {
-		const { email } = req.query;
-
+		const { userId } = req.query;
 		const networks = await getCollection('networks');
 
 		const loadUsersPromises = networks.map(async network => {
@@ -15,10 +14,10 @@ router.get('/', async (req, res, next) => {
 		await Promise.all(loadUsersPromises);
 
 		const filteredNetworks = networks.filter(network => {
-			if (network.owner === email) return true;
+			if (network.ownerId === userId) return true;
 			let isNetworkUser = false;
 			network.users.forEach(networkUser => {
-				if (networkUser.email === email) {
+				if (networkUser.userId === userId) {
 					isNetworkUser = true;
 				}
 			});
@@ -26,17 +25,6 @@ router.get('/', async (req, res, next) => {
 		});
 		return res.send(filteredNetworks);
 
-	} catch (err) {
-		next(err);
-	}
-});
-
-router.patch('/:id', async (req, res, next) => {
-	try {
-		const networkId = req.params.id;
-		const { network } = req.body;
-		const result = await updateDocument(`networks/${networkId}`, network);
-		return res.send(result);
 	} catch (err) {
 		next(err);
 	}

--- a/orchestration-api/modules/themes/ThemesController.js
+++ b/orchestration-api/modules/themes/ThemesController.js
@@ -1,13 +1,14 @@
 const { Router } = require('express');
 const admin = require('firebase-admin');
+const { getCollection, getDocument, createDocument, updateDocument, deleteDocument } = require('../../clients/FirebaseClient');
 
 const router = Router();
 
 router.get('/', async (req, res, next) => {
 	try {
 		const { networkId } = req.query;
-		const themesSnapshots = await admin.firestore().collection('networks').doc(networkId).collection('themes').get();
-		const themes = themesSnapshots.docs.map(doc => doc.data());
+		const path = `networks/${networkId}/themes`;
+		const themes = await getCollection(path);
 		return res.send(themes);
 	} catch (err) {
 		next(err);
@@ -17,10 +18,9 @@ router.get('/', async (req, res, next) => {
 router.post('/', async (req, res, next) => {
 	try {
 		const { theme, networkId } = req.body;
-		const themeDocumentRef = admin.firestore().collection('networks').doc(networkId).collection('themes').doc();
-		theme._id = themeDocumentRef.id;
-		await themeDocumentRef.set(theme);
-		return res.send(theme);
+		const path = `networks/${networkId}/themes`;
+		const result = await createDocument(path, theme);
+		return res.send(result);
 	} catch (err) {
 		next(err);
 	}
@@ -29,9 +29,9 @@ router.post('/', async (req, res, next) => {
 router.get('/:id', async (req, res, next) => {
 	try {
 		const { networkId } = req.query;
-		const themeId = req.params.id;
-		const themeSnapshot = await admin.firestore().collection('networks').doc(networkId).collection('themes').doc(themeId).get();
-		const theme = themeSnapshot.data();
+		const { id: themeId } = req.params;
+		const path = `networks/${networkId}/themes/${themeId}`;
+		const theme = await getDocument(path);
 		return res.send(theme);
 	} catch (err) {
 		next(err);
@@ -42,9 +42,9 @@ router.patch('/:id', async (req, res, next) => {
 	try {
 		const { theme, networkId } = req.body;
 		const themeId = req.params.id;
-		const themeDocumentRef = admin.firestore().collection('networks').doc(networkId).collection('themes').doc(themeId);
-		await themeDocumentRef.update(theme);
-		return res.send('done');
+		const path = `networks/${networkId}/themes/${themeId}`;
+		const result = await updateDocument(path, theme);
+		return res.send(result);
 	} catch (err) {
 		next(err);
 	}
@@ -54,9 +54,9 @@ router.delete('/:id', async (req, res, next) => {
 	try {
 		const { networkId } = req.query;
 		const themeId = req.params.id;
-		const themeDocumentRef = admin.firestore().collection('networks').doc(networkId).collection('themes').doc(themeId);
-		await themeDocumentRef.delete();
-		return res.send('done');
+		const path = `networks/${networkId}/themes/${themeId}`;
+		const result = await deleteDocument(path);
+		return res.send(result);
 	} catch (err) {
 		next(err);
 	}

--- a/orchestration-api/modules/themes/ThemesController.js
+++ b/orchestration-api/modules/themes/ThemesController.js
@@ -1,5 +1,4 @@
 const { Router } = require('express');
-const admin = require('firebase-admin');
 const { getCollection, getDocument, createDocument, updateDocument, deleteDocument } = require('../../clients/FirebaseClient');
 
 const router = Router();
@@ -18,8 +17,7 @@ router.get('/', async (req, res, next) => {
 router.post('/', async (req, res, next) => {
 	try {
 		const { theme, networkId } = req.body;
-		const path = `networks/${networkId}/themes`;
-		const result = await createDocument(path, theme);
+		const result = await createDocument(`networks/${networkId}/themes`, theme);
 		return res.send(result);
 	} catch (err) {
 		next(err);
@@ -30,8 +28,7 @@ router.get('/:id', async (req, res, next) => {
 	try {
 		const { networkId } = req.query;
 		const { id: themeId } = req.params;
-		const path = `networks/${networkId}/themes/${themeId}`;
-		const theme = await getDocument(path);
+		const theme = await getDocument(`networks/${networkId}/themes/${themeId}`);
 		return res.send(theme);
 	} catch (err) {
 		next(err);
@@ -42,8 +39,7 @@ router.patch('/:id', async (req, res, next) => {
 	try {
 		const { theme, networkId } = req.body;
 		const themeId = req.params.id;
-		const path = `networks/${networkId}/themes/${themeId}`;
-		const result = await updateDocument(path, theme);
+		const result = await updateDocument(`networks/${networkId}/themes/${themeId}`, theme);
 		return res.send(result);
 	} catch (err) {
 		next(err);
@@ -54,8 +50,7 @@ router.delete('/:id', async (req, res, next) => {
 	try {
 		const { networkId } = req.query;
 		const themeId = req.params.id;
-		const path = `networks/${networkId}/themes/${themeId}`;
-		const result = await deleteDocument(path);
+		const result = await deleteDocument(`networks/${networkId}/themes/${themeId}`);
 		return res.send(result);
 	} catch (err) {
 		next(err);

--- a/orchestration-api/modules/themes/ThemesController.js
+++ b/orchestration-api/modules/themes/ThemesController.js
@@ -5,7 +5,8 @@ const router = Router();
 
 router.get('/', async (req, res, next) => {
 	try {
-		const { networkId } = req.query;
+		const { userId } = req.query;
+		const { networkId } = await getDocument(`users/${userId}`);
 		const themes = await getCollection(`networks/${networkId}/themes`);
 		return res.send(themes);
 	} catch (err) {
@@ -15,7 +16,8 @@ router.get('/', async (req, res, next) => {
 
 router.post('/', async (req, res, next) => {
 	try {
-		const { theme, networkId } = req.body;
+		const { theme, userId } = req.body;
+		const { networkId } = await getDocument(`users/${userId}`);
 		const result = await createDocument(`networks/${networkId}/themes`, theme);
 		return res.send(result);
 	} catch (err) {
@@ -25,8 +27,9 @@ router.post('/', async (req, res, next) => {
 
 router.get('/:id', async (req, res, next) => {
 	try {
-		const { networkId } = req.query;
+		const { userId } = req.query;
 		const { id: themeId } = req.params;
+		const { networkId } = await getDocument(`users/${userId}`);
 		const theme = await getDocument(`networks/${networkId}/themes/${themeId}`);
 		return res.send(theme);
 	} catch (err) {
@@ -36,8 +39,9 @@ router.get('/:id', async (req, res, next) => {
 
 router.patch('/:id', async (req, res, next) => {
 	try {
-		const { theme, networkId } = req.body;
+		const { theme, userId } = req.body;
 		const themeId = req.params.id;
+		const { networkId } = await getDocument(`users/${userId}`);
 		const result = await updateDocument(`networks/${networkId}/themes/${themeId}`, theme);
 		return res.send(result);
 	} catch (err) {
@@ -47,8 +51,9 @@ router.patch('/:id', async (req, res, next) => {
 
 router.delete('/:id', async (req, res, next) => {
 	try {
-		const { networkId } = req.query;
+		const { userId } = req.query;
 		const themeId = req.params.id;
+		const { networkId } = await getDocument(`users/${userId}`);
 		const result = await deleteDocument(`networks/${networkId}/themes/${themeId}`);
 		return res.send(result);
 	} catch (err) {

--- a/orchestration-api/modules/themes/ThemesController.js
+++ b/orchestration-api/modules/themes/ThemesController.js
@@ -6,8 +6,7 @@ const router = Router();
 router.get('/', async (req, res, next) => {
 	try {
 		const { networkId } = req.query;
-		const path = `networks/${networkId}/themes`;
-		const themes = await getCollection(path);
+		const themes = await getCollection(`networks/${networkId}/themes`);
 		return res.send(themes);
 	} catch (err) {
 		next(err);

--- a/orchestration-api/modules/users/UsersController.js
+++ b/orchestration-api/modules/users/UsersController.js
@@ -1,13 +1,12 @@
 const { Router } = require('express');
-const admin = require('firebase-admin');
+const { getCollection, getDocument, setDocument, updateDocument, deleteDocument } = require('../../clients/FirebaseClient');
 
 const router = Router();
 
 router.get('/', async (req, res, next) => {
 	try {
 		const { networkId } = req.query;
-		const usersSnapshot = await admin.firestore().collection('networks').doc(networkId).collection('users').get();
-		const users = usersSnapshot.docs.map(doc => doc.data());
+		const users = await getCollection(`networks/${networkId}/users`);
 		return res.send(users);
 	} catch (err) {
 		next(err);
@@ -17,9 +16,8 @@ router.get('/', async (req, res, next) => {
 router.post('/', async (req, res, next) => {
 	try {
 		const { user, networkId } = req.body;
-		const userDocumentRef = await admin.firestore().collection('networks').doc(networkId).collection('users').doc(user.email);
-		await userDocumentRef.set(user);
-		return res.send('success');
+		const result = await setDocument(`/networks/${networkId}/users/${user.email}`, user);
+		return res.send(result);
 	} catch (err) {
 		next(err);
 	}
@@ -28,9 +26,8 @@ router.post('/', async (req, res, next) => {
 router.get('/:id', async (req, res, next) => {
 	try {
 		const { networkId } = req.query;
-		const userId = req.params.id;
-		const userDoc = await admin.firestore().collection('networks').doc(networkId).collection('users').doc(userId).get();
-		const user = userDoc.data();
+		const { id: userId } = req.params;
+		const user = await getDocument(`networks/${networkId}/users/${userId}`);
 		return res.send(user);
 	} catch (err) {
 		next(err);
@@ -40,10 +37,9 @@ router.get('/:id', async (req, res, next) => {
 router.patch('/:id', async (req, res, next) => {
 	try {
 		const { user, networkId } = req.body;
-		const userId = req.params.id;
-		const userDoc = await admin.firestore().collection('networks').doc(networkId).collection('users').doc(userId).get();
-		await userDoc.update(user);
-		return res.send('done');
+		const { id: userId } = req.params;
+		const result = await updateDocument(`networks/${networkId}/users/${userId}`, user);
+		return res.send(result);
 	} catch (err) {
 		next(err);
 	}
@@ -52,10 +48,9 @@ router.patch('/:id', async (req, res, next) => {
 router.delete('/:id', async (req, res, next) => {
 	try {
 		const { networkId } = req.query;
-		const userId = req.params.id;
-		const userDoc = await admin.firestore().collection('networks').doc(networkId).collection('users').doc(userId).get();
-		await userDoc.delete();
-		return res.send('done');
+		const { id: userId } = req.params;
+		const result = await deleteDocument(`networks/${networkId}/users/${userId}`)
+		return res.send(result);
 	} catch (err) {
 		next(err);
 	}

--- a/orchestration-api/routes.js
+++ b/orchestration-api/routes.js
@@ -1,5 +1,5 @@
 const LightsController = require('./modules/lights/LightsController');
-const MeController = require('./modules/networks/MeController');
+const MeController = require('./modules/me/MeController');
 const NetworksController = require('./modules/networks/NetworksController');
 const ThemesController = require('./modules/themes/ThemesController');
 const UsersController = require('./modules/users/UsersController');

--- a/orchestration-api/routes.js
+++ b/orchestration-api/routes.js
@@ -1,10 +1,12 @@
 const LightsController = require('./modules/lights/LightsController');
+const MeController = require('./modules/networks/MeController');
 const NetworksController = require('./modules/networks/NetworksController');
 const ThemesController = require('./modules/themes/ThemesController');
-const UsersController = require('./modules/users/UsersController')
+const UsersController = require('./modules/users/UsersController');
 
 module.exports = {
 	LightsController,
+	MeController,
 	NetworksController,
 	ThemesController,
 	UsersController

--- a/orchestration-ui/src/components/AppHeader.vue
+++ b/orchestration-ui/src/components/AppHeader.vue
@@ -34,7 +34,7 @@
 </template>
 
 <script>
-import { mapGetters } from 'vuex';
+import { mapGetters, mapActions } from 'vuex';
 import routes from '../router/routes';
 
 export default {
@@ -50,6 +50,14 @@ export default {
 			const menuItems = routes.filter(route => route.menuName);
 			return menuItems;
 		}
+	},
+	methods: {
+		...mapActions({
+			fetchNetwork: 'networks/fetchNetwork'
+		})
+	},
+	created() {
+		this.fetchNetwork();
 	}
 };
 </script>

--- a/orchestration-ui/src/containers/Account/Page.vue
+++ b/orchestration-ui/src/containers/Account/Page.vue
@@ -126,7 +126,7 @@ export default {
 		async onUpdateSettingsClick() {
 			this.page.isSubmitting = true;
 			try {
-				await this.updateNetwork({ network: { settings: this.networkSettings }, networkId: this.network._id });
+				await this.updateNetwork({ settings: this.networkSettings });
 				this.setupPage();
 				toastService.toast('Settings Updated');
 			} catch (err) {
@@ -142,6 +142,7 @@ export default {
 		network: {
 			immediate: true,
 			handler() {
+				if (!this.network) return;
 				this.networkSettings = this.network.settings;
 			}
 		}

--- a/orchestration-ui/src/containers/Account/Page.vue
+++ b/orchestration-ui/src/containers/Account/Page.vue
@@ -102,13 +102,17 @@ export default {
 	methods: {
 		...mapActions({
 			fetchNetworks: 'networks/fetchNetworks',
+			fetchNetwork: 'networks/fetchNetwork',
 			setCurrentNetwork: 'networks/setCurrentNetwork',
 			updateNetwork: 'networks/updateNetwork',
 			logOutUser: 'account/logOut'
 		}),
 		async setupPage() {
 			this.page.isLoading = true;
-			await this.fetchNetworks();
+			await Promise.all([
+				this.fetchNetworks(),
+				this.fetchNetwork()
+			]);
 			this.page.isLoading = false;
 		},
 		isSetNetworkActiveDisabled(network) {

--- a/orchestration-ui/src/containers/Users/List.vue
+++ b/orchestration-ui/src/containers/Users/List.vue
@@ -124,7 +124,6 @@ export default {
 	methods: {
 		...mapActions({
 			fetchUsers: 'users/fetchUsers',
-			fetchUser: 'users/fetchUser',
 			deleteUser: 'users/deleteUser'
 		}),
 		async fetch() {
@@ -137,7 +136,7 @@ export default {
 		async onConfirmDeleteClick() {
 			this.page.isSubmitting = true;
 			try {
-				await this.deleteUser(this.page.lastClickedUser.email);
+				await this.deleteUser(this.page.lastClickedUser.userId);
 				toastService.toast('User removed');
 				this.fetch();
 			} catch (err) {

--- a/orchestration-ui/src/containers/Users/components/EditUserModal.vue
+++ b/orchestration-ui/src/containers/Users/components/EditUserModal.vue
@@ -94,7 +94,7 @@ export default {
 					toastService.toast('User added');
 				} else {
 					await this.updateUserRole({
-						email: this.email,
+						userId: this.user._id,
 						role: this.role
 					});
 					toastService.toast('User updated');

--- a/orchestration-ui/src/store/index.js
+++ b/orchestration-ui/src/store/index.js
@@ -16,10 +16,7 @@ const provider = new firebase.auth.GoogleAuthProvider();
 
 const persistedState = new VuexPersistence({
 	supportCsircular: true,
-	modules: [
-		'account',
-		'networks'
-	]
+	modules: ['account']
 });
 
 const storeConfig = {

--- a/orchestration-ui/src/store/modules/lights.js
+++ b/orchestration-ui/src/store/modules/lights.js
@@ -14,23 +14,23 @@ export default {
 	},
 	actions: {
 		async fetchLights({ commit, rootGetters }, options = {}) {
-			const { _id: networkId } = rootGetters['networks/network'];
+			const { uid: userId } = rootGetters['account/account'].user;
 			const { data: lights } = await axios.get(
 				`${config.API_BASE}/lights`,
 				{
-					params: { networkId }
+					params: { userId }
 				}
 			);
 			if (!options.skipCommit) commit('SET_LIGHTS', lights);
 			return lights;
 		},
 		async updateLights({ rootGetters }, lights) {
-			const { _id: networkId } = rootGetters['networks/network'];
+			const { uid: userId } = rootGetters['account/account'].user;
 			const result = await axios.post(
 				`${config.API_BASE}/lights/update`,
 				{
 					lights,
-					networkId
+					userId
 				}
 			);
 			return result;

--- a/orchestration-ui/src/store/modules/lights.js
+++ b/orchestration-ui/src/store/modules/lights.js
@@ -17,9 +17,7 @@ export default {
 			const { uid: userId } = rootGetters['account/account'].user;
 			const { data: lights } = await axios.get(
 				`${config.API_BASE}/lights`,
-				{
-					params: { userId }
-				}
+				{ params: { userId } }
 			);
 			if (!options.skipCommit) commit('SET_LIGHTS', lights);
 			return lights;
@@ -28,10 +26,7 @@ export default {
 			const { uid: userId } = rootGetters['account/account'].user;
 			const result = await axios.post(
 				`${config.API_BASE}/lights/update`,
-				{
-					lights,
-					userId
-				}
+				{ lights, userId }
 			);
 			return result;
 		}

--- a/orchestration-ui/src/store/modules/networks.js
+++ b/orchestration-ui/src/store/modules/networks.js
@@ -17,8 +17,16 @@ export default {
 		}
 	},
 	actions: {
-		setCurrentNetwork({ commit }, network) {
-			commit('SET_NETWORK', network);
+		async setCurrentNetwork({ rootGetters }, network) {
+			const { email } = rootGetters['account/account'].user;
+			const result = await axios.patch(
+				`${config.API_BASE}/me/networkId`,
+				{
+					userId: email,
+					networkId: network._id
+				}
+			);
+			return result;
 		},
 		async fetchNetworks({ commit, rootGetters }, options = {}) {
 			const { email } = rootGetters['account/account'].user;

--- a/orchestration-ui/src/store/modules/networks.js
+++ b/orchestration-ui/src/store/modules/networks.js
@@ -34,25 +34,26 @@ export default {
 					params: { userId }
 				}
 			);
-			if (!options.skipCommit) commit('SET_NETWORKS', network);
+			if (!options.skipCommit) commit('SET_NETWORK', network);
 			return network;
 		},
 		async fetchNetworks({ commit, rootGetters }, options = {}) {
-			const { email } = rootGetters['account/account'].user;
+			const { uid: userId } = rootGetters['account/account'].user;
 
 			const { data: networks } = await axios.get(
 				`${config.API_BASE}/networks`,
 				{
-					params: { email }
+					params: { userId }
 				}
 			);
 			if (!options.skipCommit) commit('SET_NETWORKS', networks);
 			return networks;
 		},
-		async updateNetwork(vuex, { network, networkId }) {
+		async updateNetwork({ rootGetters }, network) {
+			const { uid: userId } = rootGetters['account/account'].user;
 			const result = await axios.patch(
-				`${config.API_BASE}/networks/${networkId}`,
-				{ network }
+				`${config.API_BASE}/me/network`,
+				{ userId, network }
 			);
 			return result;
 		}

--- a/orchestration-ui/src/store/modules/networks.js
+++ b/orchestration-ui/src/store/modules/networks.js
@@ -17,16 +17,25 @@ export default {
 		}
 	},
 	actions: {
-		async setCurrentNetwork({ rootGetters }, network) {
-			const { email } = rootGetters['account/account'].user;
+		async setCurrentNetwork({ rootGetters }, { _id: networkId }) {
+			const { uid: userId } = rootGetters['account/account'].user;
 			const result = await axios.patch(
 				`${config.API_BASE}/me/networkId`,
-				{
-					userId: email,
-					networkId: network._id
-				}
+				{ userId, networkId }
 			);
 			return result;
+		},
+		async fetchNetwork({ commit, rootGetters }, options = {}) {
+			const { uid: userId } = rootGetters['account/account'].user;
+
+			const { data: network } = await axios.get(
+				`${config.API_BASE}/me/network`,
+				{
+					params: { userId }
+				}
+			);
+			if (!options.skipCommit) commit('SET_NETWORKS', network);
+			return network;
 		},
 		async fetchNetworks({ commit, rootGetters }, options = {}) {
 			const { email } = rootGetters['account/account'].user;

--- a/orchestration-ui/src/store/modules/themes.js
+++ b/orchestration-ui/src/store/modules/themes.js
@@ -18,55 +18,45 @@ export default {
 	},
 	actions: {
 		async fetchTheme({ commit, rootGetters }, id) {
-			const { _id: networkId } = rootGetters['networks/network'];
+			const { uid: userId } = rootGetters['account/account'].user;
 			const { data: theme } = await axios.get(
 				`${config.API_BASE}/themes/${id}`,
-				{
-					params: { networkId }
-				}
+				{ params: { userId } }
 			);
 			commit('SET_THEME', theme);
 			return theme;
 		},
 		async fetchThemes({ commit, rootGetters }, options = {}) {
-			const { _id: networkId } = rootGetters['networks/network'];
+			const { uid: userId } = rootGetters['account/account'].user;
 			const { data: themes } = await axios.get(
 				`${config.API_BASE}/themes`,
-				{
-					params: { networkId }
-				}
+				{ params: { userId } }
 			);
 			if (!options.skipCommit) commit('SET_THEMES', themes);
 			return themes;
 		},
 		async updateTheme({ rootGetters }, theme) {
-			const { _id: networkId } = rootGetters['networks/network'];
+			const { uid: userId } = rootGetters['account/account'].user;
 			const result = await axios.patch(
 				`${config.API_BASE}/themes/${theme._id}`,
-				{
-					theme,
-					networkId
-				}
+				{ theme, userId }
 			);
 			return result;
 		},
 		async createTheme({ rootGetters }, theme) {
-			const { _id: networkId } = rootGetters['networks/network'];
+			const { uid: userId } = rootGetters['account/account'].user;
 			const result = await axios.post(
 				`${config.API_BASE}/themes`,
-				{
-					theme,
-					networkId
-				}
+				{ theme, userId }
 			);
 			return result;
 		},
 		async deleteTheme({ rootGetters }, theme) {
-			const { _id: networkId } = rootGetters['networks/network'];
+			const { uid: userId } = rootGetters['account/account'].user;
 			const result = await axios.delete(
 				`${config.API_BASE}/themes/${theme._id}`,
 				{
-					params: { networkId }
+					params: { userId }
 				}
 			);
 			return result;

--- a/orchestration-ui/src/store/modules/users.js
+++ b/orchestration-ui/src/store/modules/users.js
@@ -17,60 +17,41 @@ export default {
 		}
 	},
 	actions: {
-		async fetchUser({ commit, rootGetters }, email) {
-			const { _id: networkId } = rootGetters['networks/network'];
-			const { data: user } = await axios.get(
-				`${config.API_BASE}/users/${email}`,
-				{
-					params: { networkId }
-				}
-			);
-			commit('SET_USER', user);
-			return user;
-		},
 		async fetchUsers({ commit, rootGetters }, options = {}) {
-			const network = rootGetters['networks/network'];
+			const { uid } = rootGetters['account/account'].user;
 			const { data: users } = await axios.get(
 				`${config.API_BASE}/users`,
-				{
-					params: { networkId: network._id }
-				}
+				{ params: { userId: uid } }
 			);
-			users.push({
-				email: network.owner,
-				role: 'owner'
-			});
 			if (!options.skipCommit) commit('SET_USERS', users);
 			return users;
 		},
 		async createUser({ rootGetters }, { email, role }) {
-			const { _id: networkId } = rootGetters['networks/network'];
+			const { uid } = rootGetters['account/account'].user;
 			const result = await axios.post(
 				`${config.API_BASE}/users`,
 				{
 					user: { email, role },
-					networkId
+					userId: uid
 				}
 			);
 			return result;
 		},
-		async deleteUser({ rootGetters }, email) {
-			const { _id: networkId } = rootGetters['networks/network'];
+		async deleteUser({ rootGetters }, userId) {
+			const { uid } = rootGetters['account/account'].user;
 			const result = await axios.delete(
-				`${config.API_BASE}/users/${email}`,
-				{
-					params: { networkId }
-				}
+				`${config.API_BASE}/users/${userId}`,
+				{ params: { userId: uid } }
 			);
 			return result;
 		},
-		async updateUserRole({ rootGetters }, { email, role }) {
-			const { _id: networkId } = rootGetters['networks/network'];
+		async updateUserRole({ rootGetters }, { userId, role }) {
+			const { uid } = rootGetters['account/account'].user;
 			const result = await axios.patch(
-				`${config.API_BASE}/users/${email}`,
+				`${config.API_BASE}/users/${userId}`,
 				{
-					user: { email, role },
-					networkId
+					user: { userId, role },
+					userId: uid
 				}
 			);
 			return result;


### PR DESCRIPTION
This is to allow us to set a default network as outlined in #29 

## Changes

### Features
- add `/me` endpoint to orchestration api, allowing a user to load their own data, and update their currently selected network

### Chores
- refactor orchestration-api to use a FirebaseClient to act on the database to increase readability
- network is no longer stored locally, and instead stored against the current account object

## After merging
- [x] remove deprecated users from all networks with an email and their id
- [x] remove deprecated `owner` field from networks